### PR TITLE
Fix for IE 7 encoding issue

### DIFF
--- a/src/jquery.address.js
+++ b/src/jquery.address.js
@@ -135,7 +135,7 @@
             },
             _html = function() {
                 var src = _js() + ':' + FALSE + ';document.open();document.writeln(\'<html><head><title>' + 
-                    _d.title.replace('\'', '\\\'') + '</title><script>var ' + ID + ' = "' + _href() + 
+                    _d.title.replace('\'', '\\\'') + '</title><script>var ' + ID + ' = "' + encodeURIComponent(_href()) + 
                     (_d.domain != _l.host ? '";document.domain="' + _d.domain : '') + 
                     '";</' + 'script></head></html>\');document.close();';
                 if (_version < 7) {


### PR DESCRIPTION
There's a problem with encoding some special characters in IE7 using version 1.3 of the plugin.

Example: http://www.asual.com/jquery/address/samples/state/#/about?q=b%C3%B8rn
The q parameter spells "børn" and gets translated into "bÃ¸rn".
