### PR TITLE
Ignore clicks when modifier key held down

### DIFF
--- a/src/jquery.address.js
+++ b/src/jquery.address.js
@@ -748,6 +748,8 @@
     $.fn.address = function(fn) {
         if (!$(this).attr('address')) {
             var f = function(e) {
+                // if they're holding a modifier let it go through: they're trying to open in a new window or tab
+                if (e.shiftKey || e.ctrlKey || e.metaKey) { return true; }
                 if ($(this).is('a')) {
                     var value = fn ? fn.call(this) : 
                         /address:/.test($(this).attr('rel')) ? $(this).attr('rel').split('address:')[1].split(' ')[0] : 


### PR DESCRIPTION
Super simple addition to pass the click through when a modifier key (shift, ctrl, meta) is held down, indicating the user wants a new window or tab. Center click was working already, as was right-click and then choosing an option, but we had a designer who uses Cmd-click all the time and noticed this bug.

Thanks for a great library!
