### PR TITLE
IE error with encoded images

### DIFF
--- a/src/jquery.address.js
+++ b/src/jquery.address.js
@@ -77,8 +77,13 @@
             _search = function(el) {
                 var url, s;
                 for (var i = 0, l = el.childNodes.length; i < l; i++) {
-                    if (el.childNodes[i].src) {
-                        url = String(el.childNodes[i].src);
+                    try {
+                      if (el.childNodes[i].src) {
+                          url = String(el.childNodes[i].src);
+                      }
+                    } catch (e) {
+                      // IE has a problem with base64 encoded images, it raises an Invalid pointer when the
+                      // source field is accessed
                     }
                     s = _search(el.childNodes[i]);
                     if (s) {


### PR DESCRIPTION
IE raises an exception when you attempt to access the 'src' attribute of an ImageElement for which the source is a base64 encoded PNG. I simply wrapped this in a try/catch and ignored the error.
