### PR TITLE
Fixed scoping

### DIFF
--- a/src/jquery.address.js
+++ b/src/jquery.address.js
@@ -129,7 +129,7 @@
             },
             _options = function() {
                 if (_url && _qi != -1) {
-                    var param, params = _url.substr(_qi + 1).split('&');
+                    var i, param, params = _url.substr(_qi + 1).split('&');
                     for (i = 0; i < params.length; i++) {
                         param = params[i].split('=');
                         if (/^(autoUpdate|crawlable|history|strict|wrap)$/.test(param[0])) {


### PR DESCRIPTION
An 'i' variable used by a foreach was not scoped to its function, making it a global variable. This can cause conflicts with other scripts on the page (particularly with such a common name).
