### PR TITLE
Fix URL foreign languages support on IE7.

### DIFF
--- a/src/jquery.address.js
+++ b/src/jquery.address.js
@@ -118,7 +118,7 @@
             },
             _html = function() {
                 var src = _js() + ':' + FALSE + ';document.open();document.writeln(\'<html><head><title>' + 
-                    _d.title.replace('\'', '\\\'') + '</title><script>var ' + ID + ' = "' + encodeURIComponent(_href()) + 
+                    _d.title.replace('\'', '\\\'') + '</title><script>var ' + ID + ' = "' + _href() + 
                     (_d.domain != _l.hostname ? '";document.domain="' + _d.domain : '') + 
                     '";</' + 'script></head></html>\');document.close();';
                 if (_version < 7) {


### PR DESCRIPTION
Fix URL foreign languages support on IE7.
Other way URL /контакты will be redirected to /#!/ÐºÐ¾Ð½ÑÐ°ÐºÑÑ
