### PR TITLE
IFRAME in Opera & Security error fix

### DIFF
--- a/src/jquery.address.js
+++ b/src/jquery.address.js
@@ -60,7 +60,7 @@
             },
             _window = function() {
                 try {
-                    return top.document !== UNDEFINED ? top : window;
+                    return top.document !== UNDEFINED && top.document.title !== UNDEFINED ? top : window;
                 } catch (e) { 
                     return window;
                 }


### PR DESCRIPTION
Opera forbids accessing top.document properties such as "title" or event "onhashchanged" from IFRAME and throws error "Uncaught exception: ReferenceError: Security error: attempted to read protected variable: onhashchange." Since _window method only checks for top.document property I suggest to add top.document.title check either - exception will be thrown and code will return reference to window instead of top. 
