### PR TITLE
Fix for single quote character in parameter triggering external change

### DIFF
--- a/src/jquery.address.js
+++ b/src/jquery.address.js
@@ -84,7 +84,7 @@
             _listen = function() {
                 if (!_silent) {
                     var hash = _href(),
-                        diff = _value != hash;
+                        diff = decodeURI(_value) != decodeURI(hash);
                     if (diff) {
                         if (_msie && _version < 7) {
                             _l.reload();
@@ -248,7 +248,7 @@
                 _st(fn, delay);
             },
             _popstate = function() {
-                if (_value != _href()) {
+                if (decodeURI(_value) != decodeURI(_href())) {
                     _value = _href();
                     _update(FALSE);
                 }

--- a/test/test.js
+++ b/test/test.js
@@ -243,6 +243,22 @@ asyncTest('Character test', function() {
     }, 1000);
 });
 
+asyncTest('Single quote test', function() {
+    setTimeout(function() {
+        var externalChange = 0;
+        var testFunction = function() {
+            externalChange++;
+            equals(externalChange, 0);
+        };
+        var ignore = false;
+        $.address.value('/')
+            .bind('externalChange', testFunction)
+            .parameter('p', "Patrick's Test")
+            .unbind('externalChange', testFunction);
+        start();
+    }, 1000);
+});
+
 asyncTest('Value test', function() {
     setTimeout(function() {
         $.address.value(1);


### PR DESCRIPTION
I found an issue where setting a parameter that contains a single quote ( ' ) triggers an external change event in Firefox. This is due to the fact that Firefox encodes a single quote as %27 when retrieving it via window.location.href but it does not encode the single quote when using the encodeURI() and encodeURIComponent() methods. I have provided a test case and a fix that should resolve the issue. Thanks!
