### PR TITLE
build.xml now creates a dist directory if it does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# ignore genereated files
+dist/
+

--- a/build.xml
+++ b/build.xml
@@ -32,6 +32,8 @@
     </target>
     
     <target name="dist">
+        <mkdir dir="${dist.dir}"/>
+
         <delete includeemptydirs="true">
             <fileset dir="${dist.dir}" includes="**/*" />
         </delete>


### PR DESCRIPTION
- build now creates a dist directory if it does not exist (fixes build failure on a freshly cloned repo)
- gitignore ignores dist directory
