### PR TITLE
support for new google analytics.js tracker

### DIFF
--- a/src/jquery.address.js
+++ b/src/jquery.address.js
@@ -101,6 +101,8 @@
                         _t.pageTracker._trackPageview(value);
                     } else if (_t._gaq !== UNDEFINED && $.isFunction(_t._gaq.push)) {
                         _t._gaq.push(['_trackPageview', decodeURI(value)]);
+                    } else if ($.isFunction(_t.ga)) {
+                        _t.ga('send', 'pageview', value);
                     }
                 }
             },


### PR DESCRIPTION
Support for new analytics.js tracker, see

https://developers.google.com/analytics/devguides/collection/analyticsjs/pages

Fixes #177
