### PR TITLE
Fix MSIE detection *Urgent*

### DIFF
--- a/src/jquery.address.js
+++ b/src/jquery.address.js
@@ -277,7 +277,7 @@
             _browser = _detectBrowser(),
             _version = parseFloat(_browser.version),
             _webkit = _browser.webkit || _browser.safari,
-            _msie = !$.support.opacity,
+            _msie = _browser.msie,
             _t = _window(),
             _d = _t.document,
             _h = _t.history, 


### PR DESCRIPTION
MSIE detection is failing in newer jQuery because `$.support.opacity` is undefined, this is causing all browsers to be detected as IE.

This means all pages are getting a [`setInterval`](https://github.com/asual/jquery-address/blob/master/src/jquery.address.js#L211) instead of using the `hashchange` event which causes drastic performance issues.
